### PR TITLE
Add an API to set name of primary eni.

### DIFF
--- a/lib/aws-wrapper/ec2/instance.rb
+++ b/lib/aws-wrapper/ec2/instance.rb
@@ -95,6 +95,19 @@ module AwsWrapper
         false
       end
 
+      def set_primary_eni_name(name)
+        nis = @instance[:network_interface_set]
+        raise AWS::EC2::Errors::IncorrectInstanceState if nis.empty?
+        nis.each do |ni|
+          next unless ni[:attachment][:device_index] == 0
+          nid = ni[:network_interface_id]
+          target_eni = AwsWrapper::Ec2::NetworkInterface.new(nid)
+          target_eni.set_name(name)
+          return
+        end
+        raise AWS::EC2::Errors::IncorrectInstanceState
+      end
+
       class << self
         def create(name, ami_id, instance_type, options = {})
           options[:image_id] = ami_id

--- a/lib/aws-wrapper/ec2/network_interface.rb
+++ b/lib/aws-wrapper/ec2/network_interface.rb
@@ -138,6 +138,10 @@ module AwsWrapper
         @aws_interface.set_security_groups(security_group_ids)
       end
 
+      def set_name(name)
+        @aws_interface.add_tag("Name", :value => name)
+      end
+
       class << self
         def create(name, subnet, options = {})
           subnet_info = AwsWrapper::Ec2::Subnet.find(subnet)


### PR DESCRIPTION
Two new api is added.  The one is an api to set name for interface, and the other is to set
name for primary network interface of an instance.
